### PR TITLE
Make connection constant optional

### DIFF
--- a/manifest.lkml
+++ b/manifest.lkml
@@ -19,6 +19,6 @@ application: api-explorer {
 }
 
 constant: CONNECTION_NAME {
-  value: "choose-connection"
-  export: override_required
+  value: ""
+  export: override_optional
 }


### PR DESCRIPTION
Means connection does not have to be selected when extension is installed.

Permissions still work despite a connection not being associated with the model. The model is happy because it has a constant defined. It does not seem to care that the constant value is empty. Auto install no longer has to define a value for connection.

Suggest we modify data dictionary and lookml diagram. We should let this bake in for a few days before doing so though.