### PR TITLE
add sri hash to manifest

### DIFF
--- a/manifest.lkml
+++ b/manifest.lkml
@@ -3,7 +3,7 @@ project_name: "api-explorer"
 application: api-explorer {
   label: "API Explorer"
   file: "bundle.js"
-  sri_hash: "sH1e19WGQ1eaLbjplhpNlqcqRSIxgdOEN9RBAFwb8+VqCm8SWKTlYl0EUYWxK6Y3%"
+  sri_hash: "sH1e19WGQ1eaLbjplhpNlqcqRSIxgdOEN9RBAFwb8+VqCm8SWKTlYl0EUYWxK6Y3"
 
   entitlements: {
     local_storage: yes

--- a/manifest.lkml
+++ b/manifest.lkml
@@ -3,6 +3,7 @@ project_name: "api-explorer"
 application: api-explorer {
   label: "API Explorer"
   file: "bundle.js"
+  sri_hash: "sH1e19WGQ1eaLbjplhpNlqcqRSIxgdOEN9RBAFwb8+VqCm8SWKTlYl0EUYWxK6Y3%"
 
   entitlements: {
     local_storage: yes


### PR DESCRIPTION
Generate and add SRI hash to manifest. This is a requirement for extension that is tied to Looker 21.8 or greater. For posterity it can be generated with the following command:
```
openssl dgst -sha384 -binary bundle.js | openssl base64 -A
``` 
It's also a good automation candidate that would be part of the apix deploy script.